### PR TITLE
Authenticate downloads using credentials from user settings.xml

### DIFF
--- a/src/main/java/org/apache/maven/wrapper/Downloader.java
+++ b/src/main/java/org/apache/maven/wrapper/Downloader.java
@@ -22,5 +22,5 @@ import java.net.URI;
  * @author Hans Dockter
  */
 public interface Downloader {
-  void download(URI address, File destination) throws Exception;
+  void download(URI address, File destination, String[] args) throws Exception;
 }

--- a/src/main/java/org/apache/maven/wrapper/Installer.java
+++ b/src/main/java/org/apache/maven/wrapper/Installer.java
@@ -48,7 +48,7 @@ public class Installer {
     this.pathAssembler = pathAssembler;
   }
 
-  public File createDist(WrapperConfiguration configuration) throws Exception {
+  public File createDist(WrapperConfiguration configuration, String[] args) throws Exception {
     URI distributionUrl = configuration.getDistribution();
     boolean alwaysDownload = configuration.isAlwaysDownload();
     boolean alwaysUnpack = configuration.isAlwaysUnpack();
@@ -61,7 +61,7 @@ public class Installer {
       File tmpZipFile = new File(localZipFile.getParentFile(), localZipFile.getName() + ".part");
       tmpZipFile.delete();
       System.out.println("Downloading " + distributionUrl);
-      download.download(distributionUrl, tmpZipFile);
+      download.download(distributionUrl, tmpZipFile, args);
       tmpZipFile.renameTo(localZipFile);
       downloaded = true;
     }

--- a/src/main/java/org/apache/maven/wrapper/MavenSettings.java
+++ b/src/main/java/org/apache/maven/wrapper/MavenSettings.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.maven.wrapper;
+
+import java.io.BufferedInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathExpressionException;
+import javax.xml.xpath.XPathFactory;
+
+import org.xml.sax.InputSource;
+
+class MavenSettings {
+  private static final XPathFactory xpathFactory = XPathFactory.newInstance();
+
+  public static class Credentials {
+    public final String username;
+    public final String password;
+
+    Credentials(String username, String password) {
+      this.username = username;
+      this.password = password;
+    }
+  }
+
+  public static File getUserSettings(String[] args) {
+    for (int i = 0; i < args.length - 1; i++) {
+      String arg = args[i];
+      if ("-s".equals(arg) || "--settings".equals(arg)) {
+        return new File(args[i+1]);
+      }
+    }
+    String userHome = System.getProperty("user.home");
+    return new File(userHome, ".m2/settings.xml");
+  }
+
+  public static Credentials getCredentials(String[] args, String serverId) {
+    if (serverId == null) {
+      return null;
+    }
+
+    File userSettings = getUserSettings(args);
+    try (InputStream is = new BufferedInputStream(new FileInputStream(userSettings))) {
+      InputSource xml = new InputSource(is);
+      XPath xpath = xpathFactory.newXPath();
+
+      Object servers = xpath.compile("/settings/servers").evaluate(xml, XPathConstants.NODE);
+      if (servers != null) {
+        String username = xpath.compile("server[id='" + serverId + "']/username").evaluate(servers);
+        String password = xpath.compile("server[id='" + serverId + "']/password").evaluate(servers);
+        if (username != null && !username.isEmpty()) {
+          return new Credentials(username, password);
+        }
+      }
+    } catch (IOException | XPathExpressionException e) {
+      // ignore, nothing to be done about it
+    }
+
+    return null;
+  }
+
+}

--- a/src/main/java/org/apache/maven/wrapper/WrapperExecutor.java
+++ b/src/main/java/org/apache/maven/wrapper/WrapperExecutor.java
@@ -118,7 +118,7 @@ public class WrapperExecutor {
   }
 
   public void execute(String[] args, Installer install, BootstrapMainStarter bootstrapMainStarter) throws Exception {
-    File mavenHome = install.createDist(config);
+    File mavenHome = install.createDist(config, args);
     bootstrapMainStarter.start(args, mavenHome);
   }
 

--- a/src/test/java/org/apache/maven/wrapper/DownloaderTest.java
+++ b/src/test/java/org/apache/maven/wrapper/DownloaderTest.java
@@ -29,6 +29,7 @@ public class DownloaderTest {
     testDir = new File("target/test-files/DownloadTest");
     rootDir = new File(testDir, "root");
     downloadFile = new File(rootDir, "file");
+    downloadFile.delete();
     remoteFile = new File(testDir, "remoteFile");
     FileUtils.write(remoteFile, "sometext");
     sourceRoot = remoteFile.toURI();
@@ -36,8 +37,8 @@ public class DownloaderTest {
 
   @Test
   public void testDownload() throws Exception {
-    assert !downloadFile.exists();
-    download.download(sourceRoot, downloadFile);
+    assert!downloadFile.exists();
+    download.download(sourceRoot, downloadFile, new String[0]);
     assert downloadFile.exists();
     assertEquals("sometext", FileUtils.readFileToString(downloadFile));
   }

--- a/src/test/java/org/apache/maven/wrapper/InstallerTest.java
+++ b/src/test/java/org/apache/maven/wrapper/InstallerTest.java
@@ -87,7 +87,7 @@ public class InstallerTest {
   }
 
   public void testCreateDist() throws Exception {
-    File homeDir = install.createDist(configuration);
+    File homeDir = install.createDist(configuration, new String[0]);
 
     Assert.assertEquals(mavenHomeDir, homeDir);
     Assert.assertTrue(homeDir.isDirectory());
@@ -110,7 +110,7 @@ public class InstallerTest {
     File someFile = new File(mavenHomeDir, "some-file");
     FileUtils.touch(someFile);
 
-    File homeDir = install.createDist(configuration);
+    File homeDir = install.createDist(configuration, new String[0]);
 
     Assert.assertEquals(mavenHomeDir, homeDir);
     Assert.assertTrue(mavenHomeDir.isDirectory());
@@ -131,7 +131,7 @@ public class InstallerTest {
     FileUtils.touch(garbage);
     configuration.setAlwaysUnpack(true);
 
-    File homeDir = install.createDist(configuration);
+    File homeDir = install.createDist(configuration, new String[0]);
 
     Assert.assertEquals(mavenHomeDir, homeDir);
     Assert.assertTrue(mavenHomeDir.isDirectory());
@@ -151,7 +151,7 @@ public class InstallerTest {
     FileUtils.touch(garbage);
     configuration.setAlwaysUnpack(true);
 
-    File homeDir = install.createDist(configuration);
+    File homeDir = install.createDist(configuration, new String[0]);
 
     Assert.assertEquals(mavenHomeDir, homeDir);
     Assert.assertTrue(mavenHomeDir.isDirectory());

--- a/src/test/java/org/apache/maven/wrapper/WrapperExecutorTest.java
+++ b/src/test/java/org/apache/maven/wrapper/WrapperExecutorTest.java
@@ -30,7 +30,7 @@ public class WrapperExecutorTest {
 
   public WrapperExecutorTest() throws Exception {
     install = mock(Installer.class);
-    when(install.createDist(Mockito.any(WrapperConfiguration.class))).thenReturn(mockInstallDir);
+    when(install.createDist(Mockito.any(WrapperConfiguration.class), Mockito.any(String[].class))).thenReturn(mockInstallDir);
     start = mock(BootstrapMainStarter.class);
 
     testDir.mkdirs();
@@ -106,7 +106,7 @@ public class WrapperExecutorTest {
     wrapper.execute(new String[] {
       "arg"
     }, install, start);
-    verify(install).createDist(Mockito.any(WrapperConfiguration.class));
+    verify(install).createDist(Mockito.any(WrapperConfiguration.class), Mockito.any(String[].class));
     verify(start).start(new String[] {
       "arg"
     }, mockInstallDir);


### PR DESCRIPTION
If distributionUrl contains userInfo, that user info will be matched
to settings.xml <server> id element. If the match is found, <server>
username and password elements will be used to authenticate the
distribution download. If there is no match (or not user settings,
etc), the download will proceed without authentication.

Implementation will first use -s/--settings command line arguments
to locate user settings files, then fall back to ~/.m2/settings.xml
location.

Signed-off-by: Igor Fedorenko ifedorenko@salesforce.com
