### PR TITLE
Align Un*x and Windows scripts to both use MAVEN_CONFIG consistently

### DIFF
--- a/mvnw
+++ b/mvnw
@@ -230,5 +230,5 @@ exec "$JAVACMD" \
   $MAVEN_OPTS \
   -classpath "./.mvn/wrapper/maven-wrapper.jar" \
   "-Dmaven.home=${M2_HOME}" "-Dmaven.multiModuleProjectDirectory=${MAVEN_PROJECTBASEDIR}" \
-  ${WRAPPER_LAUNCHER} "$@"
+  ${WRAPPER_LAUNCHER} $MAVEN_CMD_LINE_ARGS
 

--- a/mvnw.cmd
+++ b/mvnw.cmd
@@ -80,7 +80,7 @@ goto error
 
 :init
 
-set MAVEN_CMD_LINE_ARGS=%*
+set MAVEN_CMD_LINE_ARGS=%MAVEN_CONFIG% %*
 
 @REM Find the project base dir, i.e. the directory that contains the folder ".mvn".
 @REM Fallback to current working directory if not found.


### PR DESCRIPTION
Tested on Ubuntu 14.04 and Windows 7 64bit.

Fixes gh-3
