### PR TITLE
Fix while loop so that basedir is detected in current dir

### DIFF
--- a/mvnw
+++ b/mvnw
@@ -200,11 +200,11 @@ find_maven_basedir() {
   local basedir=$(pwd)
   local wdir=$(pwd)
   while [ "$wdir" != '/' ] ; do
-    wdir=$(cd "$wdir/.."; pwd)
     if [ -d "$wdir"/.mvn ] ; then
       basedir=$wdir
       break
     fi
+    wdir=$(cd "$wdir/.."; pwd)
   done
   echo "${basedir}"
 }


### PR DESCRIPTION
There was a problem with the logic in the while loop that detects
the base dir - it should first look in the current directory,
otherwise you can't build in a directory with local settings because
it will always climb up and find .mvn in a parent directory (e.g. user's
home).
