### PR TITLE
[fixed] Quoted arguments weren't properly passed through ./mvnw to maven.

### DIFF
--- a/mvnw
+++ b/mvnw
@@ -230,5 +230,5 @@ exec "$JAVACMD" \
   $MAVEN_OPTS \
   -classpath "$MAVEN_PROJECTBASEDIR/.mvn/wrapper/maven-wrapper.jar" \
   "-Dmaven.home=${M2_HOME}" "-Dmaven.multiModuleProjectDirectory=${MAVEN_PROJECTBASEDIR}" \
-  ${WRAPPER_LAUNCHER} $MAVEN_CMD_LINE_ARGS
+  ${WRAPPER_LAUNCHER} $MAVEN_CONFIG "$@"
 


### PR DESCRIPTION
# See the Problem

Run this without maven-wrapper:

`mvn help:evaluate -Dfoo="bar baz" -Dexpression="foo"`

Output:

```
[INFO] Scanning for projects...
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] Building Maven Stub Project (No POM) 1
[INFO] ------------------------------------------------------------------------
[INFO]
[INFO] --- maven-help-plugin:2.2:evaluate (default-cli) @ standalone-pom ---
[INFO] No artifact parameter specified, using 'org.apache.maven:standalone-pom:pom:1' as project.
[INFO]
bar baz
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 0.645 s
[INFO] Finished at: 2015-11-09T15:39:46-06:00
[INFO] Final Memory: 9M/245M
[INFO] ------------------------------------------------------------------------
```

But try it with maven-wrapper:

`./mvnw help:evaluate -Dfoo="bar baz" -Dexpression="foo"`

And get this:

```
[INFO] Scanning for projects...
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] Building mvnw13 1.0.0-SNAPSHOT
[INFO] ------------------------------------------------------------------------
[INFO]
[INFO] --- maven-help-plugin:2.2:evaluate (default-cli) @ mvnw13 ---
[INFO] No artifact parameter specified, using 'com.example:mvnw13:jar:1.0.0-SNAPSHOT' as project.
[INFO]
bar
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] Building mvnw13 1.0.0-SNAPSHOT
[INFO] ------------------------------------------------------------------------
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 0.895 s
[INFO] Finished at: 2015-11-09T15:41:22-06:00
[INFO] Final Memory: 17M/309M
[INFO] ------------------------------------------------------------------------
[ERROR] Unknown lifecycle phase "baz". You must specify a valid lifecycle phase or a goal in the format <plugin-prefix>:<goal> or <plugin-group-id>:<plugin-artifact-id>[:<plugin-version>]:<goal>. Available lifecycle phases are: validate, initialize, generate-sources, process-sources, generate-resources, process-resources, compile, process-classes, generate-test-sources, process-test-sources, generate-test-resources, process-test-resources, test-compile, process-test-classes, test, prepare-package, package, pre-integration-test, integration-test, post-integration-test, verify, install, deploy, pre-clean, clean, post-clean, pre-site, site, post-site, site-deploy. -> [Help 1]
[ERROR]
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR]
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/LifecyclePhaseNotFoundException
```
# What's Going On?

On line 224, the parameters that were passed in to `./mvnw` are being put inside an environment variable.

Quoted strings are handled by the shell/interpreter, and are 'magic' inasmuch as quotes are understood to delimit tokens, but are not considered part of the tokens.

When `MAVEN_CMD_LINE_ARGS="$MAVEN_CONFIG $@"`, quotes are not preserved and, to use the above example, you would end up with

`MAVEN_CMD_LINE_ARGS="$MAVEN_CONFIG help:evaluate -Dfoo=bar baz -Dexpression=foo"`

which is obviously not going to work as expected because you've got that "baz" loitering in the middle of the command.
# Real Use Case

A real use case of this is the maven-release-plugin's ["arguments" parameter](https://maven.apache.org/maven-release/maven-release-plugin/perform-mojo.html#arguments): In order to provide multiple arguments to the maven-release-plugin, they must be separated by spaces, which means the parameter value itself must be quoted, like

`mvn release:perform -Darguments="-U -X -e -Dfoo=bar -Dfee=fie"` 

If maven-wrapper doesn't pass quoted arguments through properly, it is impossible to use the -`Darguments` parameter of `release:perform`.
