### PR TITLE
Fix path escaping

### DIFF
--- a/mvnw.cmd
+++ b/mvnw.cmd
@@ -118,7 +118,7 @@ for /F "usebackq delims=" %%a in ("%MAVEN_PROJECTBASEDIR%\.mvn\jvm.config") do s
 
 SET MAVEN_JAVA_EXE="%JAVA_HOME%\bin\java.exe"
 
-set WRAPPER_JAR=""%MAVEN_PROJECTBASEDIR%\.mvn\wrapper\maven-wrapper.jar""
+set WRAPPER_JAR="%MAVEN_PROJECTBASEDIR%\.mvn\wrapper\maven-wrapper.jar"
 set WRAPPER_LAUNCHER=org.apache.maven.wrapper.MavenWrapperMain
 
 # avoid using MAVEN_CMD_LINE_ARGS below since that would loose parameter escaping in %*


### PR DESCRIPTION
If `%MAVEN_PROJECTBASEDIR%` contained whitespaces, Windows couldn't find the maven-wrapper.jar because the whitespaces were considered as argument separators.
