### PR TITLE
use @REM instead of #

### DIFF
--- a/mvnw.cmd
+++ b/mvnw.cmd
@@ -121,7 +121,7 @@ SET MAVEN_JAVA_EXE="%JAVA_HOME%\bin\java.exe"
 set WRAPPER_JAR=""%MAVEN_PROJECTBASEDIR%\.mvn\wrapper\maven-wrapper.jar""
 set WRAPPER_LAUNCHER=org.apache.maven.wrapper.MavenWrapperMain
 
-# avoid using MAVEN_CMD_LINE_ARGS below since that would loose parameter escaping in %*
+@REM avoid using MAVEN_CMD_LINE_ARGS below since that would loose parameter escaping in %*
 %MAVEN_JAVA_EXE% %JVM_CONFIG_MAVEN_PROPS% %MAVEN_OPTS% %MAVEN_DEBUG_OPTS% -classpath %WRAPPER_JAR% "-Dmaven.multiModuleProjectDirectory=%MAVEN_PROJECTBASEDIR%" %WRAPPER_LAUNCHER% %MAVEN_CONFIG% %*
 if ERRORLEVEL 1 goto error
 goto end


### PR DESCRIPTION
using # in .cmd files as comment issues the following error: `Der Befehl "#" ist entweder falsch geschrieben oder konnte nicht gefunden werden.` aka command not found
