### PR TITLE
Be defensive about creating directories for files

### DIFF
--- a/src/main/java/org/apache/maven/wrapper/Installer.java
+++ b/src/main/java/org/apache/maven/wrapper/Installer.java
@@ -170,6 +170,7 @@ public class Installer {
         continue;
       }
 
+      new File(dest, entry.getName()).getParentFile().mkdirs();
       copyInputStream(zipFile.getInputStream(entry), new BufferedOutputStream(new FileOutputStream(new File(dest, entry.getName()))));
     }
     zipFile.close();


### PR DESCRIPTION
Maven 3.4 snapshots are now being published with invalid
zip files, where the entries are listed before their parent.
So the logic in the Installer is faulty: you have to mkdirs()
on all entries to be sure that the directory exists before you
write the file.