### PR TITLE
Make artifact compatible with older Java and fix stale maven-wrapper.jar bundled with .tar.gz distribution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 .project
 .settings
 /target/
+.idea/
+*.iml

--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,1 +1,1 @@
-distributionUrl=https://repo1.maven.org/maven2/org/apache/maven/apache-maven/3.3.3/apache-maven-3.3.3-bin.zip
+distributionUrl=https://repo1.maven.org/maven2/org/apache/maven/apache-maven/3.3.9/apache-maven-3.3.9-bin.zip

--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,9 @@
       <distribution>repo</distribution>
     </license>
   </licenses>
+  <properties>
+    <javaSourceVersion>1.5</javaSourceVersion>
+  </properties>
   <dependencies>
     <dependency>
       <groupId>junit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>io.takari</groupId>
     <artifactId>takari</artifactId>
-    <version>19</version>
+    <version>23</version>
   </parent>
   
   <artifactId>maven-wrapper</artifactId>
@@ -18,7 +18,7 @@
     </license>
   </licenses>
   <properties>
-    <javaSourceVersion>1.5</javaSourceVersion>
+    <takari.javaSourceVersion>1.5</takari.javaSourceVersion>
   </properties>
   <dependencies>
     <dependency>
@@ -65,7 +65,7 @@
       <plugin>
         <groupId>io.takari.maven.plugins</groupId>
         <artifactId>provisio-maven-plugin</artifactId>
-        <version>0.1.17</version>
+        <version>0.1.44</version>
         <extensions>true</extensions>
       </plugin>
     </plugins>

--- a/src/main/provisio/wrapper.xml
+++ b/src/main/provisio/wrapper.xml
@@ -2,7 +2,7 @@
   <archive name="${project.artifactId}-${project.version}.tar.gz" />
   
   <artifactSet to="/.mvn/wrapper">
-     <artifact ref="projectArtifact" as="maven-wrapper.jar"/> 
+     <artifact ref="projectArtifact" as="maven-wrapper.jar"/>
   </artifactSet>
   
   <fileSet to="/">
@@ -10,6 +10,7 @@
       <include>mvnw</include>
       <include>mvnw.cmd</include>
       <include>.mvn/**</include>
+      <exclude>**/*.jar</exclude>
     </directory>
   </fileSet>
 </runtime>


### PR DESCRIPTION
Makes it possible to use Maven Wrapper with Maven 3.2.x on Java 6 among other combinations