### PR TITLE
Use of bashisms make this script fail in minimal /bin/sh implementations like dash

### DIFF
--- a/mvnw
+++ b/mvnw
@@ -196,7 +196,13 @@ if [ -z "$BASE_DIR" ]; then
   exit 1;
 fi
 
-export MAVEN_PROJECTBASEDIR=${MAVEN_BASEDIR:-"$BASE_DIR"}
+# Workaround for JBEAP-8937 (do not change, it may break on Solaris)
+if [ -z "${MAVEN_PROJECTBASEDIR}" ]; then
+  export MAVEN_PROJECTBASEDIR=`find_maven_basedir`
+fi
+# End of fix
+
+
 echo $MAVEN_PROJECTBASEDIR
 MAVEN_OPTS="$(concat_lines "$MAVEN_PROJECTBASEDIR/.mvn/jvm.config") $MAVEN_OPTS"
 


### PR DESCRIPTION
Issue: [Use of bashisms make this script fail in minimal /bin/sh implementations like dash](https://github.com/takari/maven-wrapper/issues/34)
Related to the following [JBEAP-8927](https://issues.jboss.org/browse/JBEAP-8937)