### PR TITLE
Fixing issues on Solaris 10 (Sparc)

### DIFF
--- a/mvnw
+++ b/mvnw
@@ -172,14 +172,18 @@ find_maven_basedir() {
     return 1
   fi
 
-  local basedir="$1"
-  local wdir="$1"
+  basedir="$1"
+  wdir="$1"
   while [ "$wdir" != '/' ] ; do
     if [ -d "$wdir"/.mvn ] ; then
       basedir=$wdir
       break
     fi
-    wdir=$(cd "$wdir/.."; pwd)
+    # workaround for JBEAP-8937 (on Solaris 10/Sparc)
+    if [ -d "${wdir}" ]; then
+      wdir=`cd "$wdir/.."; pwd`
+    fi
+    # end of workaround
   done
   echo "${basedir}"
 }
@@ -196,13 +200,7 @@ if [ -z "$BASE_DIR" ]; then
   exit 1;
 fi
 
-# Workaround for JBEAP-8937 (do not change, it may break on Solaris)
-if [ -z "${MAVEN_PROJECTBASEDIR}" ]; then
-  export MAVEN_PROJECTBASEDIR=`find_maven_basedir`
-fi
-# End of fix
-
-
+export MAVEN_PROJECTBASEDIR=${MAVEN_BASEDIR:-"$BASE_DIR"}
 echo $MAVEN_PROJECTBASEDIR
 MAVEN_OPTS="$(concat_lines "$MAVEN_PROJECTBASEDIR/.mvn/jvm.config") $MAVEN_OPTS"
 


### PR DESCRIPTION
Issue: [JBEAP-8937](https://issues.jboss.org/browse/JBEAP-8937)

It was a bit painful to get to this point, so here is some clarification / explanation:

# 1) Current master is not "Solaris" proof (see [Build #22](https://jenkins.hosts.mwqe.eng.bos.redhat.com/hudson/job/eap-7x-as-testsuite-misc-build_scripts-solaris-rpelisse/22/) - if you have access to it)

So first of all, I can confirm that the master of maven-wrapper
[0085e9f9....a6](https://github.com/takari/maven-wrapper/commit/0085e9f96def9dc47a80ad75bae3e143822bd9a6) is not passing on both on Solaris 10 and 11, for two different reasons. 

On Solaris 11, apparently the keyword 'local' is not recognized:

```
+ ./mvnw clean install
08:06:28 ./mvnw[175]: local: not found [No such file or directory]
08:06:28 ./mvnw[176]: local: not found [No such file or directory]
08:06:28 Build step 'Execute shell' marked build as failure
```

Here is a snippet of the code not being recognized by the Solaris interpreter:

```
local basedir="$1"
local wdir="$1"
while [ "$wdir" != '/' ] ; do

```

On Solaris 10, we are running in our now familliar substituion issue (see JBEAP-8937) - but on a different line:

```
08:06:31 + ./mvnw clean install
08:06:32 ./mvnw: syntax error at line 182: `wdir=$' unexpected

```
Here is a snippet of the code being not recognized in Solaris 10:

`wdir=$(cd "$wdir/.."; pwd)
`

_Note:_
* _So, yes, 'local' appears to work on Solaris 10, but fails on Solaris 11. No comment._
* _Builds on Solaris 10 and 11 with x86_64 have no issues._

# 2) Removes local and switch substitution to backtick (Build #25)

This fixed the build on Solaris 11, but Solaris 10 stil chocked on the substituion:

`./mvnw: syntax error at line 182: `wdir=$' unexpected`

_Note: On Solaris 11, Maven fails to download some dependencies, but script fully works and does fire mvn, so, for the matter at hands, it works._

# 3) Adding a surrounding - useless, 'if' statement - as it appears to have work for JBEAP-8937 (See [Build #35](https://jenkins.hosts.mwqe.eng.bos.redhat.com/hudson/job/eap-7x-as-testsuite-misc-build_scripts-solaris-rpelisse/35) - if you have access to it)

Again, the builds are failing, but after passing through the mvnw script, due to a failed download which has corrupted the associated maven repo.

Note that I have removed the change coming from [PR39](https://github.com/takari/maven-wrapper/pull/39) because it's not compatible with the current state of mvnw.


@mosabua I would recommend using PMD or Checkstyle (or something similar) to check that nobody is introducing again the 'local' parameters (which is a shame, but as long as the plan is to somehow support Solaris 10 &11...)

