### PR TITLE
Unofficially support older Java versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 .settings
 /target/
 .DS_Store
+.idea/
+*.iml

--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,9 @@
       <distribution>repo</distribution>
     </license>
   </licenses>
+  <properties>
+    <takari.javaSourceVersion>1.5</takari.javaSourceVersion>
+  </properties>
   <dependencies>
     <dependency>
       <groupId>junit</groupId>


### PR DESCRIPTION
Unofficially support older Java versions. Maven 3.2.x supports Java 6, and Maven 3.1.x and earlier support Java 5. In the future, support for Java 5 will have to be removed to build with Java 9, if building with javac.