### PR TITLE
Add "--wrapper-version" argument to show wrapper version

### DIFF
--- a/src/main/java/org/apache/maven/wrapper/MavenWrapperMain.java
+++ b/src/main/java/org/apache/maven/wrapper/MavenWrapperMain.java
@@ -41,13 +41,16 @@ public class MavenWrapperMain {
     File propertiesFile = wrapperProperties(wrapperJar);
     File rootDir = rootDir(wrapperJar);
 
+    String wrapperVersion = wrapperVersion();
+    System.out.println("Maven Wrapper: " + wrapperVersion);
+
     Properties systemProperties = System.getProperties();
     systemProperties.putAll(parseSystemPropertiesFromArgs(args));
 
     addSystemProperties(rootDir);
 
     WrapperExecutor wrapperExecutor = WrapperExecutor.forWrapperPropertiesFile(propertiesFile, System.out);
-    wrapperExecutor.execute(args, new Installer(new DefaultDownloader("mvnw", wrapperVersion()), new PathAssembler(mavenUserHome())), new BootstrapMainStarter());
+    wrapperExecutor.execute(args, new Installer(new DefaultDownloader("mvnw", wrapperVersion), new PathAssembler(mavenUserHome())), new BootstrapMainStarter());
   }
 
   private static Map<String, String> parseSystemPropertiesFromArgs(String[] args) {


### PR DESCRIPTION
Adding special handling to `--wrapper-version` argument.

Since all maven commands are delegated to plexus launcher, intercept `--wrapper-version` argument, printout wrapper version, then exit the execution before calling plexus launcher.

Relates to #44
