### PR TITLE
Remove unnecessary echo of $MAVEN_PROJECTBASEDIR

### DIFF
--- a/mvnw
+++ b/mvnw
@@ -201,7 +201,6 @@ if [ -z "$BASE_DIR" ]; then
 fi
 
 export MAVEN_PROJECTBASEDIR=${MAVEN_BASEDIR:-"$BASE_DIR"}
-echo $MAVEN_PROJECTBASEDIR
 MAVEN_OPTS="$(concat_lines "$MAVEN_PROJECTBASEDIR/.mvn/jvm.config") $MAVEN_OPTS"
 
 # For Cygwin, switch paths to Windows format before running java


### PR DESCRIPTION
This would disturb the output if used e.g. in

    VERSION=$(./mvnw -q -Dexec.executable="echo" -Dexec.args='${project.version}' --non-recursive org.codehaus.mojo:exec-maven-plugin:1.5.0:exec)

However, I'm not sure, this is relevant anymore, since with the latest SNAPSHOT, the wrapper will output its version, e.g.

    $ VERSION=$(./mvnw -q -Dexec.executable="echo" -Dexec.args='${project.version}' --non-recursive org.codehaus.mojo:exec-maven-plugin:1.5.0:exec)
    $ echo $VERSION
    Takari Maven Wrapper: 0.2.2-SNAPSHOT 0.2.2-SNAPSHOT

To fix the example above, I simply added "tail -1" to the command, so that only the last line is taken as the version:

    $ VERSION=$(./mvnw -q -Dexec.executable="echo" -Dexec.args='${project.version}' --non-recursive org.codehaus.mojo:exec-maven-plugin:1.5.0:exec | tail -1)
    $ echo $VERSION
    0.2.2-SNAPSHOT
