### PR TITLE
Don't echo the MAVEN_PROJECTBASEDIR

### DIFF
--- a/mvnw
+++ b/mvnw
@@ -201,7 +201,6 @@ if [ -z "$BASE_DIR" ]; then
 fi
 
 export MAVEN_PROJECTBASEDIR=${MAVEN_BASEDIR:-"$BASE_DIR"}
-echo $MAVEN_PROJECTBASEDIR
 MAVEN_OPTS="$(concat_lines "$MAVEN_PROJECTBASEDIR/.mvn/jvm.config") $MAVEN_OPTS"
 
 # For Cygwin, switch paths to Windows format before running java


### PR DESCRIPTION
This breaks scripts depending on the Maven output