### PR TITLE
Fix NPE due to missing MVNW_VERBOSE

### DIFF
--- a/src/main/java/org/apache/maven/wrapper/MavenWrapperMain.java
+++ b/src/main/java/org/apache/maven/wrapper/MavenWrapperMain.java
@@ -39,7 +39,7 @@ public class MavenWrapperMain {
   public static final String MVNW_VERBOSE = "MVNW_VERBOSE";
 
   public static void main(String[] args) throws Exception {
-    Boolean verbose = System.getenv(MVNW_VERBOSE).equalsIgnoreCase("true");
+    boolean verbose = "true".equalsIgnoreCase(System.getenv(MVNW_VERBOSE));
 
     File wrapperJar = wrapperJar();
     File propertiesFile = wrapperProperties(wrapperJar);


### PR DESCRIPTION
With the latest, 0.2.2

```
./mvnw --version
Exception in thread "main" java.lang.NullPointerException
	at org.apache.maven.wrapper.MavenWrapperMain.main(MavenWrapperMain.java:42)
```

This was due to `System.getenv(MVNW_VERBOSE).equalsIgnoreCase("true")`.
Updated to handle when env value is `null`.
