### PR TITLE
set title of command window

### DIFF
--- a/mvnw.cmd
+++ b/mvnw.cmd
@@ -35,6 +35,8 @@
 
 @REM Begin all REM lines with '@' in case MAVEN_BATCH_ECHO is 'on'
 @echo off
+@REM set title of command window
+title %0
 @REM enable echoing my setting MAVEN_BATCH_ECHO to 'on'
 @if "%MAVEN_BATCH_ECHO%" == "on"  echo %MAVEN_BATCH_ECHO%
 


### PR DESCRIPTION
I work with JHipster on windows, which leaves multiple mvnw command windows open.
having a title makes it more easy to select the correct window. 

title command is pretty harmless: 
it's ignored if not applicable and is supported by all windows versions. 
https://technet.microsoft.com/en-us/library/bb491017.aspx