### PR TITLE
respect MVNW_VERBOSE when printing diagnostic stuff

### DIFF
--- a/src/main/java/org/apache/maven/wrapper/DefaultDownloader.java
+++ b/src/main/java/org/apache/maven/wrapper/DefaultDownloader.java
@@ -77,13 +77,13 @@ public class DefaultDownloader implements Downloader {
       while ((numRead = in.read(buffer)) != -1) {
         progressCounter += numRead;
         if (progressCounter / PROGRESS_CHUNK > 0) {
-          System.out.print(".");
+          Logger.info(".");
           progressCounter = progressCounter - PROGRESS_CHUNK;
         }
         out.write(buffer, 0, numRead);
       }
     } finally {
-      System.out.println("");
+      Logger.info("");
       if (in != null) {
         in.close();
       }

--- a/src/main/java/org/apache/maven/wrapper/Installer.java
+++ b/src/main/java/org/apache/maven/wrapper/Installer.java
@@ -60,7 +60,7 @@ public class Installer {
     if (alwaysDownload || !localZipFile.exists()) {
       File tmpZipFile = new File(localZipFile.getParentFile(), localZipFile.getName() + ".part");
       tmpZipFile.delete();
-      System.out.println("Downloading " + distributionUrl);
+      Logger.info("Downloading " + distributionUrl);
       download.download(distributionUrl, tmpZipFile);
       tmpZipFile.renameTo(localZipFile);
       downloaded = true;
@@ -71,10 +71,10 @@ public class Installer {
 
     if (downloaded || alwaysUnpack || dirs.isEmpty()) {
       for (File dir : dirs) {
-        System.out.println("Deleting directory " + dir.getAbsolutePath());
+        Logger.info("Deleting directory " + dir.getAbsolutePath());
         deleteDir(dir);
       }
-      System.out.println("Unzipping " + localZipFile.getAbsolutePath() + " to " + distDir.getAbsolutePath());
+      Logger.info("Unzipping " + localZipFile.getAbsolutePath() + " to " + distDir.getAbsolutePath());
       unzip(localZipFile, distDir);
       dirs = listDirs(distDir);
       if (dirs.isEmpty()) {
@@ -110,7 +110,7 @@ public class Installer {
       ProcessBuilder pb = new ProcessBuilder("chmod", "755", mavenCommand.getCanonicalPath());
       Process p = pb.start();
       if (p.waitFor() == 0) {
-        System.out.println("Set executable permissions for: " + mavenCommand.getAbsolutePath());
+        Logger.info("Set executable permissions for: " + mavenCommand.getAbsolutePath());
       } else {
         BufferedReader is = new BufferedReader(new InputStreamReader(p.getInputStream()));
         Formatter stdout = new Formatter();
@@ -126,8 +126,8 @@ public class Installer {
       errorMessage = e.getMessage();
     }
     if (errorMessage != null) {
-      System.out.println("Could not set executable permissions for: " + mavenCommand.getAbsolutePath());
-      System.out.println("Please do this manually if you want to use maven.");
+      Logger.warn("Could not set executable permissions for: " + mavenCommand.getAbsolutePath());
+      Logger.warn("Please do this manually if you want to use maven.");
     }
   }
 

--- a/src/main/java/org/apache/maven/wrapper/Logger.java
+++ b/src/main/java/org/apache/maven/wrapper/Logger.java
@@ -1,0 +1,18 @@
+package org.apache.maven.wrapper;
+
+/**
+ * @author <a href="mailto:konstantin.sobolev@gmail.com">Konstantin Sobolev</a>
+ */
+public class Logger {
+  private static final boolean VERBOSE = "true".equalsIgnoreCase(MavenWrapperMain.MVNW_VERBOSE);
+
+  public static void info(String msg) {
+    if (VERBOSE) {
+      System.out.println(msg);
+    }
+  }
+
+  public static void warn(String msg) {
+    System.out.println(msg);
+  }
+}

--- a/src/main/java/org/apache/maven/wrapper/Logger.java
+++ b/src/main/java/org/apache/maven/wrapper/Logger.java
@@ -4,7 +4,7 @@ package org.apache.maven.wrapper;
  * @author <a href="mailto:konstantin.sobolev@gmail.com">Konstantin Sobolev</a>
  */
 public class Logger {
-  private static final boolean VERBOSE = "true".equalsIgnoreCase(MavenWrapperMain.MVNW_VERBOSE);
+  private static final boolean VERBOSE = "true".equalsIgnoreCase(System.getenv(MavenWrapperMain.MVNW_VERBOSE));
 
   public static void info(String msg) {
     if (VERBOSE) {

--- a/src/main/java/org/apache/maven/wrapper/MavenWrapperMain.java
+++ b/src/main/java/org/apache/maven/wrapper/MavenWrapperMain.java
@@ -39,17 +39,12 @@ public class MavenWrapperMain {
   public static final String MVNW_VERBOSE = "MVNW_VERBOSE";
 
   public static void main(String[] args) throws Exception {
-    boolean verbose = "true".equalsIgnoreCase(System.getenv(MVNW_VERBOSE));
-
     File wrapperJar = wrapperJar();
     File propertiesFile = wrapperProperties(wrapperJar);
     File rootDir = rootDir(wrapperJar);
 
     String wrapperVersion = wrapperVersion();
-
-    if (verbose) {
-      System.out.println("Takari Maven Wrapper " + wrapperVersion);
-    }
+    Logger.info("Takari Maven Wrapper " + wrapperVersion);
 
     Properties systemProperties = System.getProperties();
     systemProperties.putAll(parseSystemPropertiesFromArgs(args));

--- a/src/test/java/org/apache/maven/wrapper/DownloaderTest.java
+++ b/src/test/java/org/apache/maven/wrapper/DownloaderTest.java
@@ -29,6 +29,8 @@ public class DownloaderTest {
     testDir = new File("target/test-files/DownloadTest");
     rootDir = new File(testDir, "root");
     downloadFile = new File(rootDir, "file");
+    if (downloadFile.exists())
+      downloadFile.delete();
     remoteFile = new File(testDir, "remoteFile");
     FileUtils.write(remoteFile, "sometext");
     sourceRoot = remoteFile.toURI();


### PR DESCRIPTION
mvnw shouldn't print anything on the screen unless explicitly asked for, otherwise it breaks scripts that expect no extra output when running `mvnw --quiet`