### PR TITLE
Support authentication on artifacts download location

### DIFF
--- a/.mvn/wrapper/MavenWrapperDownloader.java
+++ b/.mvn/wrapper/MavenWrapperDownloader.java
@@ -98,6 +98,16 @@ public class MavenWrapperDownloader {
     }
 
     private static void downloadFileFromURL(String urlString, File destination) throws Exception {
+        if (System.getenv("MVNW_WRAPPER_AUTH_USERNAME") != null && System.getenv("MVNW_WRAPPER_AUTH_PASSWORD") != null) {
+            String username = System.getenv("MVNW_WRAPPER_AUTH_USERNAME");
+            char[] password = System.getenv("MVNW_WRAPPER_AUTH_PASSWORD").toCharArray();
+            Authenticator.setDefault(new Authenticator() {
+                @Override
+                protected PasswordAuthentication getPasswordAuthentication() {
+                    return new PasswordAuthentication(username, password);
+                }
+            });
+        }
         URL website = new URL(urlString);
         ReadableByteChannel rbc;
         rbc = Channels.newChannel(website.openStream());

--- a/README.md
+++ b/README.md
@@ -83,6 +83,10 @@ download the file from the URL specified in
 download is attempted via curl, wget and, as last resort, by compiling the 
 `./mvn/wrapper/MavenWrapperDownloader.java` file and executing the resulting class.
 
+If your maven repository is password protected you can specify your username via the 
+environment variable `MVNW_WRAPPER_AUTH_USERNAME` and the password via the environment
+variable `MVNW_WRAPPER_AUTH_PASSWORD`.
+
 ## Using a Different Version of Maven
 
 To switch the version of Maven used to build a project you can initialize it using 

--- a/mvnw
+++ b/mvnw
@@ -225,12 +225,21 @@ else
         if [ "$MVNW_VERBOSE" = true ]; then
           echo "Found wget ... using wget"
         fi
-        wget "$jarUrl" -O "$wrapperJarPath"
+        if [ -z "$MVNW_WRAPPER_AUTH_USERNAME" ] || [ -z "$MVNW_WRAPPER_AUTH_PASSWORD" ]; then
+            wget "$jarUrl" -O "$wrapperJarPath"
+        else
+            wget --http-user=$MVNW_WRAPPER_AUTH_USERNAME --http-password=$MVNW_WRAPPER_AUTH_PASSWORD "$jarUrl" -O "$wrapperJarPath"
+        fi
     elif command -v curl > /dev/null; then
         if [ "$MVNW_VERBOSE" = true ]; then
           echo "Found curl ... using curl"
         fi
-        curl -o "$wrapperJarPath" "$jarUrl"
+        if [ -z "$MVNW_WRAPPER_AUTH_USERNAME" ] || [ -z "$MVNW_WRAPPER_AUTH_PASSWORD" ]; then
+            curl -o "$wrapperJarPath" "$jarUrl" -f
+        else
+            curl --user $MVNW_WRAPPER_AUTH_USERNAME:$MVNW_WRAPPER_AUTH_PASSWORD -o "$wrapperJarPath" "$jarUrl" -f
+        fi
+        
     else
         if [ "$MVNW_VERBOSE" = true ]; then
           echo "Falling back to using Java to download"

--- a/mvnw.cmd
+++ b/mvnw.cmd
@@ -132,7 +132,14 @@ if exist %WRAPPER_JAR% (
 ) else (
     echo Couldn't find %WRAPPER_JAR%, downloading it ...
 	echo Downloading from: %DOWNLOAD_URL%
-    powershell -Command "(New-Object Net.WebClient).DownloadFile('%DOWNLOAD_URL%', '%WRAPPER_JAR%')"
+	
+    powershell -Command "&{"^
+		"$webclient = new-object System.Net.WebClient;"^
+		"if (-not ([string]::IsNullOrEmpty('%MVNW_WRAPPER_AUTH_USERNAME%') -and [string]::IsNullOrEmpty('%MVNW_WRAPPER_AUTH_PASSWORD%'))) {"^
+		"$webclient.Credentials = new-object System.Net.NetworkCredential('%MVNW_WRAPPER_AUTH_USERNAME%', '%MVNW_WRAPPER_AUTH_PASSWORD%');"^
+		"}"^
+		"$webclient.DownloadFile('%DOWNLOAD_URL%', '%WRAPPER_JAR%')"^
+		"}"
     echo Finished downloading %WRAPPER_JAR%
 )
 @REM End of extension

--- a/src/main/java/org/apache/maven/wrapper/DefaultDownloader.java
+++ b/src/main/java/org/apache/maven/wrapper/DefaultDownloader.java
@@ -43,11 +43,22 @@ public class DefaultDownloader implements Downloader {
     this.applicationName = applicationName;
     this.applicationVersion = applicationVersion;
     configureProxyAuthentication();
+    configureAuthentication();
   }
 
   private void configureProxyAuthentication() {
     if (System.getProperty("http.proxyUser") != null) {
       Authenticator.setDefault(new SystemPropertiesProxyAuthenticator());
+    }
+  }
+  
+  private void configureAuthentication() {
+    if (System.getProperty("MVNW_WRAPPER_AUTH_USERNAME") != null && System.getProperty("MVNW_WRAPPER_AUTH_PASSWORD") != null && System.getProperty("http.proxyUser") == null) {
+      Authenticator.setDefault(new Authenticator() {
+            protected PasswordAuthentication getPasswordAuthentication() {
+                return new PasswordAuthentication(System.getProperty("MVNW_WRAPPER_AUTH_USERNAME"), System.getProperty("MVNW_WRAPPER_AUTH_PASSWORD").toCharArray());
+            }
+        });
     }
   }
 


### PR DESCRIPTION
Many servers cannot access the internet directly. I would like our ci server to be able to use mvnw. We use a maven repository (artifactory) to cache and validate artifacts we download. our artifactory is password protected and has different rights based on the users. I have added authentication based on environment variables as including the username and password in the URL would exposes our user and password with way too much rights.