### PR TITLE
Use project-specific maven settings.xml

### DIFF
--- a/mvnw.cmd
+++ b/mvnw.cmd
@@ -116,6 +116,12 @@ for /F "usebackq delims=" %%a in ("%MAVEN_PROJECTBASEDIR%\.mvn\jvm.config") do s
 
 :endReadAdditionalConfig
 
+IF EXIST "%MAVEN_PROJECTBASEDIR%\.mvn\settings.xml" (
+    SET MAVEN_SETTINGS_ARG= --settings "%MAVEN_PROJECTBASEDIR%\.mvn\settings.xml"
+) else (
+    SET MAVEN_SETTINGS_ARG=
+)
+
 SET MAVEN_JAVA_EXE="%JAVA_HOME%\bin\java.exe"
 set WRAPPER_JAR="%MAVEN_PROJECTBASEDIR%\.mvn\wrapper\maven-wrapper.jar"
 set WRAPPER_LAUNCHER=org.apache.maven.wrapper.MavenWrapperMain


### PR DESCRIPTION
When connecting through a corporate proxy, the maven settings must include proxy details.  
There was an existing implementation to set the java system properties using jvm.config.  But, this didn't set _maven_'s proxy configuration.  

In this change, the mvnw batch file checks for the existence of a file called `settings.xml` in the `%MAVEN_PROJECTBASEDIR%\.mvn` directory.  If a file is found there, the --settings parameter is passed at the end of the maven command line.  
If no such file is found, the parameter is not included.