### PR TITLE
On Windows, use TLS 1.2

### DIFF
--- a/mvnw.cmd
+++ b/mvnw.cmd
@@ -122,7 +122,7 @@ set WRAPPER_LAUNCHER=org.apache.maven.wrapper.MavenWrapperMain
 
 set DOWNLOAD_URL="https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.4.2/maven-wrapper-0.4.2.jar"
 FOR /F "tokens=1,2 delims==" %%A IN (%MAVEN_PROJECTBASEDIR%\.mvn\wrapper\maven-wrapper.properties) DO (
-	IF "%%A"=="wrapperUrl" SET DOWNLOAD_URL=%%B 
+    IF "%%A"=="wrapperUrl" SET DOWNLOAD_URL=%%B
 )
 
 @REM Extension to allow automatically downloading the maven-wrapper.jar from Maven-central
@@ -131,8 +131,8 @@ if exist %WRAPPER_JAR% (
     echo Found %WRAPPER_JAR%
 ) else (
     echo Couldn't find %WRAPPER_JAR%, downloading it ...
-	echo Downloading from: %DOWNLOAD_URL%
-    powershell -Command "(New-Object Net.WebClient).DownloadFile('%DOWNLOAD_URL%', '%WRAPPER_JAR%')"
+    echo Downloading from: %DOWNLOAD_URL%
+    powershell -Command "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; (New-Object Net.WebClient).DownloadFile('%DOWNLOAD_URL%', '%WRAPPER_JAR%')"
     echo Finished downloading %WRAPPER_JAR%
 )
 @REM End of extension


### PR DESCRIPTION
Github no longer supports TLS 1.0 or 1.1, but TLS 1.2 is not the default
version of TLS for PowerShell.
See https://github.com/cretueusebiu/valet-windows/issues/78#issuecomment-369824766

Also convert a couple of tabs to spaces, and remove a trailing space.

Thanks to @snuyanzin for finding this fix.

Here is the error message that appears without this fix:

```
C:\dev\calcite>mvnw
Couldn't find "C:\dev\calcite\.mvn\wrapper\maven-wrapper.jar", downloading it ...
Downloading from: "https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.4.2/maven-wrapper-0.4.2.jar"
Exception calling "DownloadFile" with "2" argument(s): "The request was aborted: Could not create SSL/TLS secure
channel."
At line:1 char:1
+ (New-Object Net.WebClient).DownloadFile('https://repo.maven.apache.org/maven2/io ...
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (:) [], MethodInvocationException
    + FullyQualifiedErrorId : WebException

Finished downloading "C:\dev\calcite\.mvn\wrapper\maven-wrapper.jar"
Error: Could not find or load main class org.apache.maven.wrapper.MavenWrapperMain
Caused by: java.lang.ClassNotFoundException: org.apache.maven.wrapper.MavenWrapperMain
```