### PR TITLE
Replace OSX with macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,7 +72,7 @@ Release performed by Manfred Moser - http://www.simpligility.com
   - also see https://github.com/takari/maven-wrapper/pull/33
   - contributed by https://github.com/vicaya
   - fixes https://github.com/takari/maven-wrapper/issues/31
-  - tested on Linux, OSX and Windows
+  - tested on Linux, macOS and Windows
 - Removed unused MAVEN_CMD_LINE_ARGS
   - see https://github.com/takari/maven-wrapper/pull/28
   - contributed by Michal Domagala - https://github.com/michaldo

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ of Maven specified in `.mvn/wrapper/maven-wrapper.properties` it will be downloa
 The wrapper should work on various operating systems including
 
 * Linux (numerous versions, tested on Ubuntu and CentOS)
-* OSX
+* macOS
 * Windows (various newer versions)
 * Solaris (10 and 11)
 


### PR DESCRIPTION
As of Sierra (10.12), Apple refers to the OS that runs on Mac hardware
as macOS.