### PR TITLE
add basic auth support

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,3 +1,3 @@
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.5.4/apache-maven-3.5.4-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.6.0/apache-maven-3.6.0-bin.zip
 wrapperUrl=https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.4.2/maven-wrapper-0.4.2.jar
 

--- a/README.md
+++ b/README.md
@@ -98,6 +98,19 @@ which works for any version except snapshots. Once you have a wrapper you can ch
 distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.2.1/apache-maven-3.2.1-bin.zip
 ```
 
+## Using Basic Authentication for Distribution download
+
+To download Maven from a location that requires Basic Authentication you have 2 options:
+
+1. Set the environment variables MVNW_USER and MVNW_PASSWORD
+
+    or
+
+2. add user and password to the distributionUrl like that:
+`distributionUrl=https://username:password@<yourserver>/maven2/org/apache/maven/apache-maven/3.2.1/apache-maven-3.2.1-bin.zip`
+
+
+
 [1]: https://github.com/takari/takari-maven-plugin
 
 

--- a/src/main/java/org/apache/maven/wrapper/DefaultDownloader.java
+++ b/src/main/java/org/apache/maven/wrapper/DefaultDownloader.java
@@ -16,16 +16,9 @@
 
 package org.apache.maven.wrapper;
 
-import java.io.BufferedOutputStream;
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.net.Authenticator;
-import java.net.PasswordAuthentication;
-import java.net.URI;
-import java.net.URL;
-import java.net.URLConnection;
+import java.io.*;
+import java.lang.reflect.Method;
+import java.net.*;
 
 /**
  * @author Hans Dockter
@@ -68,6 +61,7 @@ public class DefaultDownloader implements Downloader {
       URL url = address.toURL();
       out = new BufferedOutputStream(new FileOutputStream(destination));
       conn = url.openConnection();
+      addBasicAuthentication(address, conn);
       final String userAgentValue = calculateUserAgent();
       conn.setRequestProperty("User-Agent", userAgentValue);
       in = conn.getInputStream();
@@ -92,6 +86,54 @@ public class DefaultDownloader implements Downloader {
       }
     }
   }
+
+  private void addBasicAuthentication(URI address, URLConnection connection) throws IOException {
+    String userInfo = calculateUserInfo(address);
+    if (userInfo == null) {
+        return;
+    }
+    if (!"https".equals(address.getScheme())) {
+       Logger.info("WARNING Using HTTP Basic Authentication over an insecure connection to download the Gradle distribution. Please consider using HTTPS.");
+    }
+    connection.setRequestProperty("Authorization", "Basic " + base64Encode(userInfo));
+  }
+
+  /**
+     * Base64 encode user info for HTTP Basic Authentication.
+     *
+     * Try to use {@literal java.util.Base64} encoder which is available starting with Java 8.
+     * Fallback to {@literal javax.xml.bind.DatatypeConverter} from JAXB which is available starting with Java 6 but is not anymore in Java 9.
+     * Fortunately, both of these two Base64 encoders implement the right Base64 flavor, the one that does not split the output in multiple lines.
+     *
+     * @param userInfo user info
+     * @return Base64 encoded user info
+     * @throws RuntimeException if no public Base64 encoder is available on this JVM
+     */
+    private String base64Encode(String userInfo) {
+      ClassLoader loader = getClass().getClassLoader();
+      try {
+          Method getEncoderMethod = loader.loadClass("java.util.Base64").getMethod("getEncoder");
+          Method encodeMethod = loader.loadClass("java.util.Base64$Encoder").getMethod("encodeToString", byte[].class);
+          Object encoder = getEncoderMethod.invoke(null);
+          return (String) encodeMethod.invoke(encoder, new Object[]{userInfo.getBytes("UTF-8")});
+      } catch (Exception java7OrEarlier) {
+          try {
+              Method encodeMethod = loader.loadClass("javax.xml.bind.DatatypeConverter").getMethod("printBase64Binary", byte[].class);
+              return (String) encodeMethod.invoke(null, new Object[]{userInfo.getBytes("UTF-8")});
+          } catch (Exception java5OrEarlier) {
+              throw new RuntimeException("Downloading Gradle distributions with HTTP Basic Authentication is not supported on your JVM.", java5OrEarlier);
+          }
+      }
+  }
+
+  private String calculateUserInfo(URI uri) {
+    String username = System.getProperty("maven.wrapperUser");
+    String password = System.getProperty("maven.wrapperPassword");
+    if (username != null && password != null) {
+        return username + ':' + password;
+    }
+    return uri.getUserInfo();
+}
 
   private String calculateUserAgent() {
     String appVersion = applicationVersion;

--- a/src/main/java/org/apache/maven/wrapper/DefaultDownloader.java
+++ b/src/main/java/org/apache/maven/wrapper/DefaultDownloader.java
@@ -105,7 +105,7 @@ public class DefaultDownloader implements Downloader {
         return;
     }
     if (!"https".equals(address.getScheme())) {
-       Logger.info("WARNING Using HTTP Basic Authentication over an insecure connection to download the Maven distribution. Please consider using HTTPS.");
+       Logger.warn("WARNING Using HTTP Basic Authentication over an insecure connection to download the Maven distribution. Please consider using HTTPS.");
     }
     connection.setRequestProperty("Authorization", "Basic " + base64Encode(userInfo));
   }
@@ -133,7 +133,7 @@ public class DefaultDownloader implements Downloader {
               Method encodeMethod = loader.loadClass("javax.xml.bind.DatatypeConverter").getMethod("printBase64Binary", byte[].class);
               return (String) encodeMethod.invoke(null, new Object[]{userInfo.getBytes("UTF-8")});
           } catch (Exception java5OrEarlier) {
-              throw new RuntimeException("Downloading Maven   distributions with HTTP Basic Authentication is not supported on your JVM.", java5OrEarlier);
+              throw new RuntimeException("Downloading Maven distributions with HTTP Basic Authentication is not supported on your JVM.", java5OrEarlier);
           }
       }
   }

--- a/src/main/java/org/apache/maven/wrapper/DefaultDownloader.java
+++ b/src/main/java/org/apache/maven/wrapper/DefaultDownloader.java
@@ -16,9 +16,21 @@
 
 package org.apache.maven.wrapper;
 
-import java.io.*;
+import static org.apache.maven.wrapper.MavenWrapperMain.MVNW_PASSWORD;
+import static org.apache.maven.wrapper.MavenWrapperMain.MVNW_USER;
+
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.lang.reflect.Method;
-import java.net.*;
+import java.net.Authenticator;
+import java.net.PasswordAuthentication;
+import java.net.URI;
+import java.net.URL;
+import java.net.URLConnection;
 
 /**
  * @author Hans Dockter
@@ -93,7 +105,7 @@ public class DefaultDownloader implements Downloader {
         return;
     }
     if (!"https".equals(address.getScheme())) {
-       Logger.info("WARNING Using HTTP Basic Authentication over an insecure connection to download the Gradle distribution. Please consider using HTTPS.");
+       Logger.info("WARNING Using HTTP Basic Authentication over an insecure connection to download the Maven distribution. Please consider using HTTPS.");
     }
     connection.setRequestProperty("Authorization", "Basic " + base64Encode(userInfo));
   }
@@ -121,14 +133,14 @@ public class DefaultDownloader implements Downloader {
               Method encodeMethod = loader.loadClass("javax.xml.bind.DatatypeConverter").getMethod("printBase64Binary", byte[].class);
               return (String) encodeMethod.invoke(null, new Object[]{userInfo.getBytes("UTF-8")});
           } catch (Exception java5OrEarlier) {
-              throw new RuntimeException("Downloading Gradle distributions with HTTP Basic Authentication is not supported on your JVM.", java5OrEarlier);
+              throw new RuntimeException("Downloading Maven   distributions with HTTP Basic Authentication is not supported on your JVM.", java5OrEarlier);
           }
       }
   }
 
   private String calculateUserInfo(URI uri) {
-    String username = System.getProperty("maven.wrapperUser");
-    String password = System.getProperty("maven.wrapperPassword");
+    String username = System.getenv(MVNW_USER);
+    String password = System.getenv(MVNW_PASSWORD);
     if (username != null && password != null) {
         return username + ':' + password;
     }

--- a/src/main/java/org/apache/maven/wrapper/MavenWrapperMain.java
+++ b/src/main/java/org/apache/maven/wrapper/MavenWrapperMain.java
@@ -39,7 +39,6 @@ public class MavenWrapperMain {
   public static final String MVNW_VERBOSE = "MVNW_VERBOSE";
   public static final String MVNW_USER = "MVNW_USER";
   public static final String MVNW_PASSWORD = "MVNW_PASSWORD";
-
   
   public static void main(String[] args) throws Exception {
     File wrapperJar = wrapperJar();

--- a/src/main/java/org/apache/maven/wrapper/MavenWrapperMain.java
+++ b/src/main/java/org/apache/maven/wrapper/MavenWrapperMain.java
@@ -37,7 +37,10 @@ public class MavenWrapperMain {
   public static final String MAVEN_USER_HOME_ENV_KEY = "MAVEN_USER_HOME";
 
   public static final String MVNW_VERBOSE = "MVNW_VERBOSE";
+  public static final String MVNW_USER = "MVNW_USER";
+  public static final String MVNW_PASSWORD = "MVNW_PASSWORD";
 
+  
   public static void main(String[] args) throws Exception {
     File wrapperJar = wrapperJar();
     File propertiesFile = wrapperProperties(wrapperJar);


### PR DESCRIPTION
basically taken the code from [gradle wrapper](https://github.com/gradle/gradle/blob/master/subprojects/wrapper/src/main/java/org/gradle/wrapper/Download.java) 

This would be helpful in corporate environments with inhouse maven server with authentication enabled
(I happen to work in a company like that)
I've done this in my spare time which means no corporate copyrights are attached.