### PR TITLE
Provide a 'standardized' way to retrieve CLI arguments

### DIFF
--- a/mvnw
+++ b/mvnw
@@ -296,6 +296,11 @@ if $cygwin; then
     MAVEN_PROJECTBASEDIR=`cygpath --path --windows "$MAVEN_PROJECTBASEDIR"`
 fi
 
+# Provide a "standardized" way to retrieve the CLI args that will
+# work with both Windows and non-Windows executions.
+MAVEN_CMD_LINE_ARGS="$MAVEN_CONFIG $@"
+export MAVEN_CMD_LINE_ARGS
+
 WRAPPER_LAUNCHER=org.apache.maven.wrapper.MavenWrapperMain
 
 exec "$JAVACMD" \

--- a/mvnw.cmd
+++ b/mvnw.cmd
@@ -148,6 +148,10 @@ if exist %WRAPPER_JAR% (
 )
 @REM End of extension
 
+@REM Provide a "standardized" way to retrieve the CLI args that will
+@REM work with both Windows and non-Windows executions.
+set MAVEN_CMD_LINE_ARGS=%*
+
 %MAVEN_JAVA_EXE% %JVM_CONFIG_MAVEN_PROPS% %MAVEN_OPTS% %MAVEN_DEBUG_OPTS% -classpath %WRAPPER_JAR% "-Dmaven.multiModuleProjectDirectory=%MAVEN_PROJECTBASEDIR%" %WRAPPER_LAUNCHER% %MAVEN_CONFIG% %*
 if ERRORLEVEL 1 goto error
 goto end


### PR DESCRIPTION
The added environment variables are set in the default Maven distribution and it should be set as well in the Maven wrapper. It's standard Maven behavior that some plugins/extensions rely on this environment variable to get access to arguments. People using the Maven wrapper are getting different behavior from what they get when running it with the standard Maven distribution.

Parts were taken from here:

https://github.com/apache/maven/blob/a939654b765f06b1c1ee811a297b02e83b4ac316/apache-maven/src/bin/mvn#L186-L189

https://github.com/apache/maven/blob/a939654b765f06b1c1ee811a297b02e83b4ac316/apache-maven/src/bin/mvn.cmd#L79