### PR TITLE
Remove trailing whitespace

### DIFF
--- a/mvnw
+++ b/mvnw
@@ -246,7 +246,7 @@ else
         else
             curl --user $MVNW_USERNAME:$MVNW_PASSWORD -o "$wrapperJarPath" "$jarUrl" -f
         fi
-        
+
     else
         if [ "$MVNW_VERBOSE" = true ]; then
           echo "Falling back to using Java to download"


### PR DESCRIPTION
I know it's a meaningless change, but mvnw gets checked in and it's a minor annoyance having trailing whitespace in git diffs.