### PR TITLE
Feature/149

### DIFF
--- a/mvnw
+++ b/mvnw
@@ -223,10 +223,11 @@ else
     fi
     if [ "$MVNW_VERBOSE" = true ]; then
         echo "Reading properties from $BASE_DIR/.mvn/wrapper/maven-wrapper.properties"
+        echo "If the next lines look weird, you might have an unwanted carriage return in your maven-wrapper.properties file"
     fi
     while IFS="=" read key value; do
         if [ "$MVNW_VERBOSE" = true ]; then
-            echo "Got property: $key value: $value"
+            echo "Got property: {$key} value: {$value}"
         fi
       case "$key" in (wrapperUrl) jarUrl="$value"; break ;;
       esac

--- a/mvnw
+++ b/mvnw
@@ -223,7 +223,7 @@ else
     fi
     if [ "$MVNW_VERBOSE" = true ]; then
         echo "Reading properties from $BASE_DIR/.mvn/wrapper/maven-wrapper.properties"
-        echo "If the next lines look weird, you might have an unwanted carriage return in your maven-wrapper.properties file"
+        echo "If the next lines look weird, check your line endings in your maven-wrapper.properties file"
     fi
     while IFS="=" read key value; do
         if [ "$MVNW_VERBOSE" = true ]; then

--- a/mvnw
+++ b/mvnw
@@ -195,6 +195,11 @@ concat_lines() {
 }
 
 BASE_DIR=`find_maven_basedir "$(pwd)"`
+    
+if [ "$MVNW_VERBOSE" = true ]; then
+    echo "BASE_DIR is: ${BASE_DIR}" 
+fi
+    
 if [ -z "$BASE_DIR" ]; then
   exit 1;
 fi
@@ -216,7 +221,13 @@ else
     else
       jarUrl="https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.5.5/maven-wrapper-0.5.5.jar"
     fi
+    if [ "$MVNW_VERBOSE" = true ]; then
+        echo "Reading properties from {$BASE_DIR/.mvn/wrapper/maven-wrapper.properties}"
+    fi
     while IFS="=" read key value; do
+        if [ "$MVNW_VERBOSE" = true ]; then
+            echo "Got property: {$key} value: {$value}"
+        fi
       case "$key" in (wrapperUrl) jarUrl="$value"; break ;;
       esac
     done < "$BASE_DIR/.mvn/wrapper/maven-wrapper.properties"

--- a/mvnw
+++ b/mvnw
@@ -197,7 +197,7 @@ concat_lines() {
 BASE_DIR=`find_maven_basedir "$(pwd)"`
     
 if [ "$MVNW_VERBOSE" = true ]; then
-    echo "BASE_DIR is: ${BASE_DIR}" 
+    echo "BASE_DIR is: $BASE_DIR" 
 fi
     
 if [ -z "$BASE_DIR" ]; then
@@ -222,11 +222,11 @@ else
       jarUrl="https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.5.5/maven-wrapper-0.5.5.jar"
     fi
     if [ "$MVNW_VERBOSE" = true ]; then
-        echo "Reading properties from {$BASE_DIR/.mvn/wrapper/maven-wrapper.properties}"
+        echo "Reading properties from $BASE_DIR/.mvn/wrapper/maven-wrapper.properties"
     fi
     while IFS="=" read key value; do
         if [ "$MVNW_VERBOSE" = true ]; then
-            echo "Got property: {$key} value: {$value}"
+            echo "Got property: $key value: $value"
         fi
       case "$key" in (wrapperUrl) jarUrl="$value"; break ;;
       esac

--- a/mvnw.cmd
+++ b/mvnw.cmd
@@ -128,7 +128,7 @@ set DOWNLOAD_URL="https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0
 
 if "%MVNW_VERBOSE%" == "true" (
     echo Reading properties from %MAVEN_PROJECTBASEDIR%\.mvn\wrapper\maven-wrapper.properties
-    echo "If the next lines look weird, check your line endings in your maven-wrapper.properties file"
+    echo If the next lines look weird, check your line endings in your maven-wrapper.properties file
 )
 
 FOR /F "tokens=1,2 delims==" %%A IN ("%MAVEN_PROJECTBASEDIR%\.mvn\wrapper\maven-wrapper.properties") DO (

--- a/mvnw.cmd
+++ b/mvnw.cmd
@@ -108,6 +108,10 @@ cd "%EXEC_DIR%"
 
 :endDetectBaseDir
 
+if "%MVNW_VERBOSE%" == "true" (
+    echo MAVEN_PROJECTBASEDIR is: %MAVEN_PROJECTBASEDIR%
+)
+
 IF NOT EXIST "%MAVEN_PROJECTBASEDIR%\.mvn\jvm.config" goto endReadAdditionalConfig
 
 @setlocal EnableExtensions EnableDelayedExpansion
@@ -122,7 +126,14 @@ set WRAPPER_LAUNCHER=org.apache.maven.wrapper.MavenWrapperMain
 
 set DOWNLOAD_URL="https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.5.5/maven-wrapper-0.5.5.jar"
 
+if "%MVNW_VERBOSE%" == "true" (
+    echo Reading properties from %MAVEN_PROJECTBASEDIR%\.mvn\wrapper\maven-wrapper.properties
+)
+
 FOR /F "tokens=1,2 delims==" %%A IN ("%MAVEN_PROJECTBASEDIR%\.mvn\wrapper\maven-wrapper.properties") DO (
+    if "%MVNW_VERBOSE%" == "true" (
+        echo Got property: %%A value: %%B
+    )
     IF "%%A"=="wrapperUrl" SET DOWNLOAD_URL=%%B
 )
 

--- a/mvnw.cmd
+++ b/mvnw.cmd
@@ -128,11 +128,12 @@ set DOWNLOAD_URL="https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0
 
 if "%MVNW_VERBOSE%" == "true" (
     echo Reading properties from %MAVEN_PROJECTBASEDIR%\.mvn\wrapper\maven-wrapper.properties
+    echo "If the next lines look weird, check your line endings in your maven-wrapper.properties file"
 )
 
 FOR /F "tokens=1,2 delims==" %%A IN ("%MAVEN_PROJECTBASEDIR%\.mvn\wrapper\maven-wrapper.properties") DO (
     if "%MVNW_VERBOSE%" == "true" (
-        echo Got property: %%A value: %%B
+        echo Got property: ^(%%A^) value: ^(%%B^)
     )
     IF "%%A"=="wrapperUrl" SET DOWNLOAD_URL=%%B
 )

--- a/mvnw.cmd
+++ b/mvnw.cmd
@@ -131,7 +131,7 @@ if "%MVNW_VERBOSE%" == "true" (
     echo If the next lines look weird, check your line endings in your maven-wrapper.properties file
 )
 
-FOR /F "tokens=1,2 delims==" %%A IN ("%MAVEN_PROJECTBASEDIR%\.mvn\wrapper\maven-wrapper.properties") DO (
+FOR /F "tokens=1,2 delims==" %%A IN (' type "%MAVEN_PROJECTBASEDIR%\.mvn\wrapper\maven-wrapper.properties"') DO (
     if "%MVNW_VERBOSE%" == "true" (
         echo Got property: ^(%%A^) value: ^(%%B^)
     )


### PR DESCRIPTION
Update Maven wrapper script to provide additional debug information. Specifically:

- output calculated value for `BASE_DIR` (Unix) or `MAVEN_PROJECTBASEDIR` (Windows), which is where the `.mvn` folder should reside
- add a debug entry to state the file `maven-wrapper.properties` is being read, to ease following the debug lines
- output the key,value pairs being read from file `maven-wrapper.properties` encased in `{}` for Unix and `()` for Windows. If a broken line ending was found there, it would be part of the output or simply mess it up.

Test on Ubuntu 18.04, sample output with `MVNW_VERBOSE=false`:

````
grog@scummbar:~/IdeaProjects/maven-wrapper$ ./mvnw clean
--2019-09-24 19:18:46--  https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.5.5/maven-wrapper-0.5.5.jar
Resolving repo.maven.apache.org (repo.maven.apache.org)... 151.101.112.215
Connecting to repo.maven.apache.org (repo.maven.apache.org)|151.101.112.215|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 50710 (50K) [application/java-archive]
Saving to: ‘/home/grog/IdeaProjects/maven-wrapper/.mvn/wrapper/maven-wrapper.jar’
````

For the following two samples I modified file `maven-wrapper.properties` to include two additional lines with random values.

Sample output with `MVNW_VERBOSE=true`:

````
grog@scummbar:~/IdeaProjects/maven-wrapper$ ./mvnw clean
BASE_DIR is: /home/grog/IdeaProjects/maven-wrapper
Couldn't find .mvn/wrapper/maven-wrapper.jar, downloading it ...
Reading properties from /home/grog/IdeaProjects/maven-wrapper/.mvn/wrapper/maven-wrapper.properties
If the next lines look weird, check your line endings in your maven-wrapper.properties file
Got property: {asd} value: {lol}
Got property: {kk} value: {ll}
Got property: {distributionUrl} value: {https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.6.1/apache-maven-3.6.1-bin.zip}
Got property: {wrapperUrl} value: {https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.5.5/maven-wrapper-0.5.5.jar}
Downloading from: https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.5.5/maven-wrapper-0.5.5.jar
Found wget ... using wget
--2019-09-24 19:19:44--  https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.5.5/maven-wrapper-0.5.5.jar
Resolving repo.maven.apache.org (repo.maven.apache.org)... 151.101.112.215
Connecting to repo.maven.apache.org (repo.maven.apache.org)|151.101.112.215|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 50710 (50K) [application/java-archive]
Saving to: ‘/home/grog/IdeaProjects/maven-wrapper/.mvn/wrapper/maven-wrapper.jar’
````

sample output with `MVNW_VERBOSE=true` AND with a `maven-wrapper.properties` file that uses Windows line endings

````
grog@scummbar:~/IdeaProjects/maven-wrapper$ ./mvnw clean
BASE_DIR is: /home/grog/IdeaProjects/maven-wrapper
Couldn't find .mvn/wrapper/maven-wrapper.jar, downloading it ...
Reading properties from /home/grog/IdeaProjects/maven-wrapper/.mvn/wrapper/maven-wrapper.properties
If the next lines look weird, check your line endings in your maven-wrapper.properties file
}ot property: {asd} value: {lol
}ot property: {kk} value: {ll
}ot property: {distributionUrl} value: {https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.6.1/apache-maven-3.6.1-bin.zip
}ot property: {wrapperUrl} value: {https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.5.5/maven-wrapper-0.5.5.jar
Downloading from: https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.5.5/maven-wrapper-0.5.5.jar
Found wget ... using wget
--2019-09-24 19:44:46--  https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.5.5/maven-wrapper-0.5.5.jar%0D

````

I think there is now enough information to understand the line ending issue more easily than by simply spotting the subtle `%0D` from the URL

I modified the Windows script to do exactly the same, but do not have a Windows environment on which to test unfortunately.

Please let me know if you require changes

Thank you and have a nice day