### PR TITLE
Redirect warning to stderr

### DIFF
--- a/mvnw
+++ b/mvnw
@@ -156,7 +156,7 @@ if [ ! -x "$JAVACMD" ] ; then
 fi
 
 if [ -z "$JAVA_HOME" ] ; then
-  echo "Warning: JAVA_HOME environment variable is not set."
+  1>&2 echo "Warning: JAVA_HOME environment variable is not set."
 fi
 
 CLASSWORLDS_LAUNCHER=org.codehaus.plexus.classworlds.launcher.Launcher


### PR DESCRIPTION
Right now the warning is being printed in the stdout, which makes piping into other functions harder. 

if you execute:
```shell
./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout > output.txt
```

the result is going to be:

```
Warning: JAVA_HOME environment variable is not set.
1.0.52
```

With this change in place the output becomes:
```
1.0.52
```

The warning still is displayed in the console, but now we can work with the result. 