### PR TITLE
Get maven user home (~/.m2) with the same logic with maven

### DIFF
--- a/src/main/java/org/apache/maven/wrapper/MavenWrapperMain.java
+++ b/src/main/java/org/apache/maven/wrapper/MavenWrapperMain.java
@@ -31,10 +31,6 @@ import org.apache.maven.wrapper.cli.SystemPropertiesCommandLineConverter;
 public class MavenWrapperMain {
   public static final String DEFAULT_MAVEN_USER_HOME = System.getProperty("user.home") + "/.m2";
 
-  public static final String MAVEN_USER_HOME_PROPERTY_KEY = "maven.user.home";
-
-  public static final String MAVEN_USER_HOME_ENV_KEY = "MAVEN_USER_HOME";
-
   public static final String MVNW_VERBOSE = "MVNW_VERBOSE";
   public static final String MVNW_USERNAME = "MVNW_USERNAME";
   public static final String MVNW_PASSWORD = "MVNW_PASSWORD";
@@ -118,13 +114,6 @@ public class MavenWrapperMain {
   }
 
   private static File mavenUserHome() {
-    String mavenUserHome = System.getProperty(MAVEN_USER_HOME_PROPERTY_KEY);
-    if (mavenUserHome != null) {
-      return new File(mavenUserHome);
-    } else if ((mavenUserHome = System.getenv(MAVEN_USER_HOME_ENV_KEY)) != null) {
-      return new File(mavenUserHome);
-    } else {
-      return new File(DEFAULT_MAVEN_USER_HOME);
-    }
+    return new File(DEFAULT_MAVEN_USER_HOME);
   }
 }


### PR DESCRIPTION
Now wrapper guesses the maven user home location via system props, system envs
and at last the default location (`~/.m2`). This order is the convention of the gradle.
For maven, user home has [a fixed location](https://maven.apache.org/settings.html#Settings_Details), i.e. `~/.m2`.

For wrapper, we can still use `zipBase` and `distributionBase` to directly custom
the location of the downloaded and installed artifacts.

Moved to https://github.com/apache/maven/pull/354