### PR TITLE
Enable travis-ci for IT cases on multi platforms

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+* text=auto
+mvnw text eol=lf
+mvnw.cmd text eol=crlf
+.mvn/wrapper/maven-wrapper.properties text eol=lf
+*.jar binary

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ install:
 - find target -maxdepth 1 -name '*.jar' -a ! -name '*source*' | xargs -I {} cp {} target/maven-wrapper.jar
 - cp mvnw mvnw.cmd target/
 - mkdir -p target/.mvn/wrapper
-- test "x$TRAVIS_OS_NAME" = xwindows || cp .mvn/wrapper/MavenWrapperDownloader.java target/.mvn/wrapper/
+- cp .mvn/wrapper/MavenWrapperDownloader.java target/.mvn/wrapper/
 - sed -e '/^wrapperUrl=/d' .mvn/wrapper/maven-wrapper.properties >target/.mvn/wrapper/maven-wrapper.properties
 - echo "wrapperUrl=http://localhost:8080/target/maven-wrapper.jar" >>target/.mvn/wrapper/maven-wrapper.properties
 - mv .mvn .mvn.bak
@@ -29,11 +29,6 @@ before_script:
 - pushd target
 - set -o pipefail
 - curl http://localhost:8080/pom.xml >/dev/null || sleep 3 || curl http://localhost:8080/pom.xml >/dev/null
-
-script:
-- ./mvnw -version
-- diff maven-wrapper.jar .mvn/wrapper/maven-wrapper.jar
-- ./mvnw -version | grep 'Apache Maven'
 
 after_script:
 - popd
@@ -48,11 +43,68 @@ jobs:
     os: linux
     language: java
     jdk: openjdk8
+    services:
+    - docker
+    before_install:
+    - python -m SimpleHTTPServer 8080 &
+    - docker pull adoptopenjdk/openjdk8:alpine-slim
+    script:
+    - true =========== /bin/sh ===========
+    - ./mvnw -version
+    - diff maven-wrapper.jar .mvn/wrapper/maven-wrapper.jar
+    - ./mvnw -version | grep 'Apache Maven'
+
+    - true =========== bash ===========
+    - rm -f .mvn/wrapper/*.jar
+    - test ! -f .mvn/wrapper/maven-wrapper.jar
+    - bash ./mvnw -version
+    - diff maven-wrapper.jar .mvn/wrapper/maven-wrapper.jar
+    - bash ./mvnw -version | grep 'Apache Maven'
+
+    - true =========== bash posix mode ===========
+    - rm -f .mvn/wrapper/*.jar
+    - test ! -f .mvn/wrapper/maven-wrapper.jar
+    - bash --posix ./mvnw -version
+    - diff maven-wrapper.jar .mvn/wrapper/maven-wrapper.jar
+    - bash --posix ./mvnw -version | grep 'Apache Maven'
+
+    - true =========== dash ===========
+    - rm -f .mvn/wrapper/*.jar
+    - test ! -f .mvn/wrapper/maven-wrapper.jar
+    - dash ./mvnw -version
+    - diff maven-wrapper.jar .mvn/wrapper/maven-wrapper.jar
+    - dash ./mvnw -version | grep 'Apache Maven'
+
+    - true =========== busybox ===========
+    - rm -f .mvn/wrapper/*.jar
+    - test ! -f .mvn/wrapper/maven-wrapper.jar
+    - docker run --rm -i --net=host -v `pwd`:/cwd -v ~/.m2/repository:/root/.m2/repository -w /cwd adoptopenjdk/openjdk8:alpine-slim ./mvnw -version
+    - diff maven-wrapper.jar .mvn/wrapper/maven-wrapper.jar
+    - docker run --rm -i --net=host -v `pwd`:/cwd -v ~/.m2/repository:/root/.m2/repository -w /cwd adoptopenjdk/openjdk8:alpine-slim ./mvnw -version | grep 'Apache Maven'
 
   - name: "Test for macOS"
     os: osx
     osx_image: xcode9.3 # for jdk 8
     language: java
+    script:
+    - true =========== /bin/sh ===========
+    - ./mvnw -version
+    - diff maven-wrapper.jar .mvn/wrapper/maven-wrapper.jar
+    - ./mvnw -version | grep 'Apache Maven'
+
+    - true =========== bash ===========
+    - rm -f .mvn/wrapper/*.jar
+    - test ! -f .mvn/wrapper/maven-wrapper.jar
+    - bash ./mvnw -version
+    - diff maven-wrapper.jar .mvn/wrapper/maven-wrapper.jar
+    - bash ./mvnw -version | grep 'Apache Maven'
+
+    - true =========== bash posix mode ===========
+    - rm -f .mvn/wrapper/*.jar
+    - test ! -f .mvn/wrapper/maven-wrapper.jar
+    - bash --posix ./mvnw -version
+    - diff maven-wrapper.jar .mvn/wrapper/maven-wrapper.jar
+    - bash --posix ./mvnw -version | grep 'Apache Maven'
 
   - name: "Test for windows (MSYS/MINGW/CYGWIN/CMD)"
     os: windows

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,8 +64,8 @@ jobs:
       - /c/ProgramData/chocolatey/lib/maven/apache-maven-3.6.2
     before_install:
     - python -m SimpleHTTPServer 8080 &
-    - test -d /c/opt/jdk8/bin || choco install jdk8 -params 'installdir=c:\opt\jdk8' -y
-    - test -d /c/opt/cygwin/bin || choco install cygwin -params '/InstallDir:c:\opt\cygwin' -y
+    - test -d /c/opt/jdk8/bin || choco install jdk8 -params 'installdir=c:\\opt\\jdk8' -y
+    - test -d /c/opt/cygwin/bin || choco install cygwin -params '/InstallDir:c:\\opt\\cygwin' -y
     - test -d /c/ProgramData/chocolatey/lib/maven/apache-maven-3.6.2/bin || choco install maven --version 3.6.2 -y
     script:
     - echo ================================================

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,98 @@
+---
+os: linux
+
+language: shell
+
+cache:
+  directories:
+  - $HOME/.m2/repository
+
+before_install:
+- python -m SimpleHTTPServer 8080 &
+
+install:
+- |
+  case "$TRAVIS_OS_NAME" in
+    (linux) mvn verify ;; # only do ut on linux
+    (windows) PATH="$PATH:/c/opt/jdk8/bin" /c/ProgramData/chocolatey/lib/maven/apache-maven-3.6.2/bin/mvn verify -DskipTests ;;
+    (*) mvn verify -DskipTests ;;
+  esac
+- find target -maxdepth 1 -name '*.jar' -a ! -name '*source*' | xargs -I {} cp {} target/maven-wrapper.jar
+- cp mvnw mvnw.cmd target/
+- mkdir -p target/.mvn/wrapper
+- test "x$TRAVIS_OS_NAME" = xwindows || cp .mvn/wrapper/MavenWrapperDownloader.java target/.mvn/wrapper/
+- sed -e '/^wrapperUrl=/d' .mvn/wrapper/maven-wrapper.properties >target/.mvn/wrapper/maven-wrapper.properties
+- echo "wrapperUrl=http://localhost:8080/target/maven-wrapper.jar" >>target/.mvn/wrapper/maven-wrapper.properties
+- mv .mvn .mvn.bak
+
+before_script:
+- pushd target
+- set -o pipefail
+- curl http://localhost:8080/pom.xml >/dev/null || sleep 3 || curl http://localhost:8080/pom.xml >/dev/null
+
+script:
+- ./mvnw -version
+- diff maven-wrapper.jar .mvn/wrapper/maven-wrapper.jar
+- ./mvnw -version | grep 'Apache Maven'
+
+after_script:
+- popd
+- mv .mvn.bak .mvn
+- kill `jobs -p`
+
+jobs:
+  include:
+
+  - name: "Test for Linux"
+    stage: test
+    os: linux
+    language: java
+    jdk: openjdk8
+
+  - name: "Test for macOS"
+    os: osx
+    osx_image: xcode9.3 # for jdk 8
+    language: java
+
+  - name: "Test for windows (MSYS/MINGW/CYGWIN/CMD)"
+    os: windows
+    cache:
+      directories:
+      - $HOME/.m2/repository
+      - /c/opt/jdk8
+      - /c/opt/cygwin
+      - /c/ProgramData/chocolatey/lib/maven/apache-maven-3.6.2
+    before_install:
+    - python -m SimpleHTTPServer 8080 &
+    - test -d /c/opt/jdk8/bin || choco install jdk8 -params 'installdir=c:\opt\jdk8' -y
+    - test -d /c/opt/cygwin/bin || choco install cygwin -params '/InstallDir:c:\opt\cygwin' -y
+    - test -d /c/ProgramData/chocolatey/lib/maven/apache-maven-3.6.2/bin || choco install maven --version 3.6.2 -y
+    script:
+    - echo ================================================
+    - echo "subsystem - `uname -s`" | grep MSYS
+    - rm -f .mvn/wrapper/*.jar
+    - PATH="$PATH:/c/opt/jdk8/bin" ./mvnw -version
+    - diff maven-wrapper.jar .mvn/wrapper/maven-wrapper.jar
+    - PATH="$PATH:/c/opt/jdk8/bin" ./mvnw -version | grep -q 'Apache Maven'
+
+    - echo ================================================
+    - /c/Program\ Files/Git/bin/sh.exe -lc 'echo subsystem - `uname -s`' | grep MINGW
+    - rm -f .mvn/wrapper/*.jar
+    - /c/Program\ Files/Git/bin/sh.exe -lc 'PATH="$PATH:/c/opt/jdk8/bin" ./mvnw -version'
+    - diff maven-wrapper.jar .mvn/wrapper/maven-wrapper.jar
+    - /c/Program\ Files/Git/bin/sh.exe -lc 'PATH="$PATH:/c/opt/jdk8/bin" ./mvnw -version' | grep -q 'Apache Maven'
+
+    - echo ================================================
+    - cmd.exe /c 'c:\opt\cygwin\bin\sh.exe -lc "echo subsystem - `uname -s`"' | grep CYGWIN
+    - rm -f .mvn/wrapper/*.jar
+    - cmd.exe /c 'c:\opt\cygwin\bin\sh.exe -lc "cd build/'$TRAVIS_REPO_SLUG'/target && PATH=\"$PATH:/cygdrive/c/opt/jdk8/bin\" ./mvnw -version"'
+    - diff maven-wrapper.jar .mvn/wrapper/maven-wrapper.jar
+    - cmd.exe /c 'c:\opt\cygwin\bin\sh.exe -lc "cd build/'$TRAVIS_REPO_SLUG'/target && PATH=\"$PATH:/cygdrive/c/opt/jdk8/bin\" ./mvnw -version"' | grep -q 'Apache Maven'
+
+    - echo ================================================
+    - echo "subsystem - cmd.exe"
+    - rm -f .mvn/wrapper/*.jar
+      # now mvnw.cmd have to get a valid JAVA_HOME
+    - cmd.exe /c 'set JAVA_HOME=c:\opt\jdk8& cd build\'${TRAVIS_REPO_SLUG//\//\\}'\target & mvnw -version'
+    - diff maven-wrapper.jar .mvn/wrapper/maven-wrapper.jar
+    - cmd.exe /c 'set JAVA_HOME=c:\opt\jdk8& cd build\'${TRAVIS_REPO_SLUG//\//\\}'\target & mvnw -version' | grep -q 'Apache Maven'

--- a/mvnw.cmd
+++ b/mvnw.cmd
@@ -122,7 +122,7 @@ set WRAPPER_LAUNCHER=org.apache.maven.wrapper.MavenWrapperMain
 
 set DOWNLOAD_URL="https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.5.6/maven-wrapper-0.5.6.jar"
 
-FOR /F "tokens=1,2 delims==" %%A IN ("%MAVEN_PROJECTBASEDIR%\.mvn\wrapper\maven-wrapper.properties") DO (
+FOR /F "usebackq tokens=1,2 delims==" %%A IN ("%MAVEN_PROJECTBASEDIR%\.mvn\wrapper\maven-wrapper.properties") DO (
     IF "%%A"=="wrapperUrl" SET DOWNLOAD_URL=%%B
 )
 


### PR DESCRIPTION
IT test cases now work on the platforms:
- linux (ubuntu)  - get java from PATH, shell: /bin/sh, bash, bash posix mode, dash, busybox shell
- osx           - get java from PATH, shell: /bin/sh, bash, bash posix mode
- windows MSYS    - get java from PATH
- windows MINGW   - get java from PATH
- windows CYGWIN  - get java from PATH
- windows cmd.exe - get java from JAVA_HOME (do not support PATH now)

For passing all tests, 2 bug fixings are needed:
- correct file ending for scripts and the config file
- `mvnw.cmd` should parse the config file

[travis-ci job](https://travis-ci.org/gzm55/maven-wrapper/builds/622324321)


Moved to https://github.com/apache/maven/pull/353