### PR TITLE
#1 fix codacy issues

### DIFF
--- a/.mvn/wrapper/MavenWrapperDownloader.java
+++ b/.mvn/wrapper/MavenWrapperDownloader.java
@@ -75,12 +75,10 @@ public class MavenWrapperDownloader {
         }
         System.out.println("- Downloading from: " + url);
 
-        File outputFile = new File(baseDirectory.getAbsolutePath(), MAVEN_WRAPPER_JAR_PATH);
-        if(!outputFile.getParentFile().exists()) {
-            if(!outputFile.getParentFile().mkdirs()) {
-                System.out.println(
-                        "- ERROR creating output directory '" + outputFile.getParentFile().getAbsolutePath() + "'");
-            }
+        final File outputFile = new File(baseDirectory.getAbsolutePath(), MAVEN_WRAPPER_JAR_PATH);
+        final File parentFile = outputFile.getParentFile();
+        if(!parentFile.exists()) {
+            createFile(parentFile);
         }
         System.out.println("- Downloading to: " + outputFile.getAbsolutePath());
         try {
@@ -91,6 +89,13 @@ public class MavenWrapperDownloader {
             System.out.println("- Error downloading");
             e.printStackTrace();
             System.exit(1);
+        }
+    }
+
+    protected static void createFile(File parentFile) {
+        if(!parentFile.mkdirs()) {
+            System.out.println(
+                    "- ERROR creating output directory '" + parentFile.getAbsolutePath() + "'");
         }
     }
 

--- a/.mvn/wrapper/MavenWrapperDownloader.java
+++ b/.mvn/wrapper/MavenWrapperDownloader.java
@@ -86,11 +86,10 @@ public class MavenWrapperDownloader {
         try {
             downloadFileFromURL(url, outputFile);
             System.out.println("Done");
-            System.exit(0);
         } catch (Throwable e) {
             System.out.println("- Error downloading");
             e.printStackTrace();
-            System.exit(1);
+            throw RuntimeException(e);
         }
     }
 

--- a/.mvn/wrapper/MavenWrapperDownloader.java
+++ b/.mvn/wrapper/MavenWrapperDownloader.java
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package org.apache.maven.wrapper;
+
 import java.net.*;
 import java.io.*;
 import java.nio.channels.*;


### PR DESCRIPTION
This pr fixed the codacy issues. I hope it works but i could not test it.

btw the codacy issues:

* https://app.codacy.com/manual/FunThomas424242/plantuml-maven-plugin/file/40820563070/issues/source?bid=15799283&fileBranchId=15799417#l21
* https://app.codacy.com/manual/FunThomas424242/plantuml-maven-plugin/file/40820563070/issues/source?bid=15799283&fileBranchId=15799417#l80
* https://app.codacy.com/manual/FunThomas424242/plantuml-maven-plugin/file/40820563070/issues/source?bid=15799283&fileBranchId=15799417#l89


# Issue 1  details

Why is this an issue?
Since: PMD 3.1

Sometimes two consecutive 'if' statements can be consolidated by separating their conditions with a boolean short-circuit operator.

Example(s):

void bar() {
    if (x) {            // original implementation
        if (y) {
            // do stuff
        }
    }
}

void bar() {
    if (x && y) {        // optimized implementation
        // do stuff
    }
}
Related code pattern
These nested if statements could be combined
These nested if statements could be combined

# Issue 2 and 3   details
Why is this an issue?
Since: PMD 4.1

Web applications should not call System.exit(), since only the web container or the application server should stop the JVM. This rule also checks for the equivalent call Runtime.getRuntime().exit().

Example(s):

public void bar() {
    System.exit(0);                 // never call this when running in an application server!
}
public void foo() {
    Runtime.getRuntime().exit(0);   // never stop the JVM manually, the container will do this.
}
Related code pattern
System.exit() should not be used in J2EE/JEE apps
System.exit() should not be used in J2EE/JEE apps