### PR TITLE
Simplify if statement to fix PMD warning

### DIFF
--- a/.mvn/wrapper/MavenWrapperDownloader.java
+++ b/.mvn/wrapper/MavenWrapperDownloader.java
@@ -76,11 +76,9 @@ public class MavenWrapperDownloader {
         System.out.println("- Downloading from: " + url);
 
         File outputFile = new File(baseDirectory.getAbsolutePath(), MAVEN_WRAPPER_JAR_PATH);
-        if(!outputFile.getParentFile().exists()) {
-            if(!outputFile.getParentFile().mkdirs()) {
-                System.out.println(
-                        "- ERROR creating output directory '" + outputFile.getParentFile().getAbsolutePath() + "'");
-            }
+        if(!outputFile.getParentFile().exists() && !outputFile.getParentFile().mkdirs()) {
+            System.out.println(
+                    "- ERROR creating output directory '" + outputFile.getParentFile().getAbsolutePath() + "'");
         }
         System.out.println("- Downloading to: " + outputFile.getAbsolutePath());
         try {


### PR DESCRIPTION
Any project that uses the MavenWrapper will geht the following PMD warning (e.g. relevant of project is registered with Codacy via Github)

These nested if statements could be combined
Since: PMD 3.1
Sometimes two consecutive 'if' statements can be consolidated by separating their conditions with a boolean short-circuit operator.