### PR TITLE
Update mvnw.cmd

### DIFF
--- a/mvnw.cmd
+++ b/mvnw.cmd
@@ -120,22 +120,24 @@ SET MAVEN_JAVA_EXE="%JAVA_HOME%\bin\java.exe"
 set WRAPPER_JAR="%MAVEN_PROJECTBASEDIR%\.mvn\wrapper\maven-wrapper.jar"
 set WRAPPER_LAUNCHER=org.apache.maven.wrapper.MavenWrapperMain
 
+@REM Extension to allow automatically downloading the maven-wrapper.jar from Maven-central
+@REM This allows using the maven wrapper in projects that prohibit checking in binary data.
+
 set DOWNLOAD_URL="https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.5.6/maven-wrapper-0.5.6.jar"
 
 FOR /F "tokens=1,2 delims==" %%A IN ("%MAVEN_PROJECTBASEDIR%\.mvn\wrapper\maven-wrapper.properties") DO (
     IF "%%A"=="wrapperUrl" SET DOWNLOAD_URL=%%B
 )
 
-@REM Extension to allow automatically downloading the maven-wrapper.jar from Maven-central
-@REM This allows using the maven wrapper in projects that prohibit checking in binary data.
+if not "%MVNW_REPOURL%" == "" (
+    SET DOWNLOAD_URL="%MVNW_REPOURL%/io/takari/maven-wrapper/0.5.6/maven-wrapper-0.5.6.jar"
+)
+
 if exist %WRAPPER_JAR% (
     if "%MVNW_VERBOSE%" == "true" (
         echo Found %WRAPPER_JAR%
     )
 ) else (
-    if not "%MVNW_REPOURL%" == "" (
-        SET DOWNLOAD_URL="%MVNW_REPOURL%/io/takari/maven-wrapper/0.5.6/maven-wrapper-0.5.6.jar"
-    )
     if "%MVNW_VERBOSE%" == "true" (
         echo Couldn't find %WRAPPER_JAR%, downloading it ...
         echo Downloading from: %DOWNLOAD_URL%


### PR DESCRIPTION
Hey,

I believe I've found a bug in mvnw.cmd. Bug is making mvnw.cmd ignore a value of MVNW_REPOURL environment variable.
The cause of the bug is that Windows cmd (let it burn in hell for etherinity) performs variable substitutions inside brackets instructions (like used with if and for) before executing its content (which is very confusing when writing batch files).

I've prepared the fix. Feel free to merge it if You like.

MVNW_REPOURL substitution moved to the place where it's effective (since Windows performs all variable substtutions inside brackets before executing its content ).