### PR TITLE
Update mvnw.cmd - missing `usebackq` option in for loop

### DIFF
--- a/mvnw.cmd
+++ b/mvnw.cmd
@@ -122,7 +122,7 @@ set WRAPPER_LAUNCHER=org.apache.maven.wrapper.MavenWrapperMain
 
 set DOWNLOAD_URL="https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.5.6/maven-wrapper-0.5.6.jar"
 
-FOR /F "tokens=1,2 delims==" %%A IN ("%MAVEN_PROJECTBASEDIR%\.mvn\wrapper\maven-wrapper.properties") DO (
+FOR /F "tokens=1,2 usebackq delims==" %%A IN ("%MAVEN_PROJECTBASEDIR%\.mvn\wrapper\maven-wrapper.properties") DO (
     IF "%%A"=="wrapperUrl" SET DOWNLOAD_URL=%%B
 )
 


### PR DESCRIPTION
This for loop did NOT work correctly on windows workstation without `usebackq` option:

    17:31:59  D:\jenkins\test-project>FOR /F "tokens=1,2 delims==" %A IN ("D:\jenkins\test-project\.mvn\wrapper\maven-wrapper.properties") DO (IF "%A" == "wrapperUrl" SET DOWNLOAD_URL=%B ) 
    17:31:59  D:\jenkins\test-project>(IF "D:\jenkins\test-project\.mvn\wrapper\maven-wrapper.properties" == "wrapperUrl" SET DOWNLOAD_URL= ) 
