### PR TITLE
Maven will ship a wrapper in 4.0.0, not in 3.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 The project codebase has been accepted to be included in the upstream Apache
 Maven project itself. Currently the plan is to release the wrapper as a feature
-of the upcoming Maven 3.7.0 release. For this purpose the following resources
+of the upcoming Maven 4.0.0 release. For this purpose the following resources
 are available:
 
 - Maven developer mailing list for discussions


### PR DESCRIPTION
See:
- https://issues.apache.org/jira/browse/MNG-5937
- https://maven.apache.org/docs/3.8.1/release-notes.html#why-does-this-version-have-the-value-3-8-1