### PR TITLE
Fix bug in Windows Maven Wrapper script

### DIFF
--- a/mvnw.cmd
+++ b/mvnw.cmd
@@ -122,7 +122,7 @@ set WRAPPER_LAUNCHER=org.apache.maven.wrapper.MavenWrapperMain
 
 set DOWNLOAD_URL="https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.5.6/maven-wrapper-0.5.6.jar"
 
-FOR /F "tokens=1,2 delims==" %%A IN ("%MAVEN_PROJECTBASEDIR%\.mvn\wrapper\maven-wrapper.properties") DO (
+FOR /F "tokens=1,2 delims== usebackq" %%A IN ("%MAVEN_PROJECTBASEDIR%\.mvn\wrapper\maven-wrapper.properties") DO (
     IF "%%A"=="wrapperUrl" SET DOWNLOAD_URL=%%B
 )
 


### PR DESCRIPTION
(I am aware that this project is frozen.  However, this version of maven wrapper is still very common, including in new projects generated by Spring Initializr.  Therefore, I request this be kept open as documentation for others on how to resolve this issue.)

The `mvnw.cmd` script that has a bug in the functionality that _should_ loop over the `.mvn/wrapper/maven-wrapper.properties`, which causes the properties to not take effect.  This is especially problematic in development environments that require the use of a maven repository other than Maven Central.

To fix the issue, in mvnw.cmd edit the FOR loop at lines 125-127 to add the ` usebackq` option

```batch
FOR /F "tokens=1,2 delims== usebackq" %%A IN ("%MAVEN_PROJECTBASEDIR%\.mvn\wrapper\maven-wrapper.properties") DO (
    IF "%%A"=="wrapperUrl" SET DOWNLOAD_URL=%%B
)
```

Explanation: The double quotes around the filename causes the FOR command to treat it as string.  But adding the ` usebackq` option changes the FOR command to instead treat the double-quoted string as a filename set ([reference](https://ss64.com/nt/for_f.html))