### PR TITLE
Fix issue reading maven-wrapper.properties

### DIFF
--- a/.mvn/wrapper/MavenWrapperDownloader.java
+++ b/.mvn/wrapper/MavenWrapperDownloader.java
@@ -52,7 +52,7 @@ public class MavenWrapperDownloader {
 
         // If the maven-wrapper.properties exists, read it and check if it contains a custom
         // wrapperUrl parameter.
-        File mavenWrapperPropertyFile = new File(baseDirectory, MAVEN_WRAPPER_PROPERTIES_PATH);
+        File mavenWrapperPropertyFile = new File(baseDirectory.getAbsolutePath(), MAVEN_WRAPPER_PROPERTIES_PATH);
         String url = DEFAULT_DOWNLOAD_URL;
         if(mavenWrapperPropertyFile.exists()) {
             FileInputStream mavenWrapperPropertyFileInputStream = null;


### PR DESCRIPTION
`MavenWrapperDownloader.java` has issues with the generation of the path
for the file `maven-wrapper.properties`.  Due that the file is not
readed, an alternative url in `wrapperUrl` is ignored.

For a proof of concept, please see
<https://git.sr.ht/~jumapico/maven-wrapper-reproduce-bug>.